### PR TITLE
Add PHPUnit tests and CI integration

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -30,8 +30,6 @@ jobs:
       if: steps.composer-cache.outputs.cache-hit != 'true'
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
+    - name: Run test suite
+      run: composer run-script test
 
-    # - name: Run test suite
-    #   run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,18 @@
     "psr/log": "^1.1",
     "symfony/http-client": "^5.1 || ^6.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^9.6"
+  },
   "autoload": {
     "psr-4": {
       "Nrgone\\EmailHippo\\Validator\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "Nrgone\\EmailHippo\\Validator\\Tests\\": "tests/"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpunit"
   }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Nrgone\EmailHippo\Validator\Tests;
+
+use Nrgone\EmailHippo\Validator\ConfigInterface;
+use Nrgone\EmailHippo\Validator\Validator;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class ValidatorTest extends TestCase
+{
+    private function getValidator(array $configValues, array $responseData = []): Validator
+    {
+        /** @var ConfigInterface&\PHPUnit\Framework\MockObject\MockObject $config */
+        $config = $this->createConfiguredMock(ConfigInterface::class, $configValues);
+
+        /** @var ResponseInterface&\PHPUnit\Framework\MockObject\MockObject $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn($responseData);
+
+        /** @var HttpClientInterface&\PHPUnit\Framework\MockObject\MockObject $httpClient */
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->method('request')->willReturn($response);
+
+        /** @var LoggerInterface&\PHPUnit\Framework\MockObject\MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+
+        return new Validator($config, $httpClient, $logger);
+    }
+
+    public function testIsValidReturnsTrueWhenDisabled(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => false,
+            'getApiUrl' => '',
+            'getApiKey' => '',
+            'getMinimumHippoScore' => 0.0,
+            'isLoggingEnabled' => false,
+        ]);
+
+        $this->assertTrue($validator->isValid('test@example.com'));
+    }
+
+    public function testIsValidUsesHippoScore(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => true,
+            'getApiUrl' => 'http://api',
+            'getApiKey' => 'key',
+            'getMinimumHippoScore' => 0.5,
+            'isLoggingEnabled' => false,
+        ], [
+            'hippoTrust' => ['score' => 0.6],
+        ]);
+
+        $this->assertTrue($validator->isValid('test@example.com'));
+    }
+
+    public function testIsValidFailsWithLowScore(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => true,
+            'getApiUrl' => 'http://api',
+            'getApiKey' => 'key',
+            'getMinimumHippoScore' => 0.9,
+            'isLoggingEnabled' => false,
+        ], [
+            'hippoTrust' => ['score' => 0.1],
+        ]);
+
+        $this->assertFalse($validator->isValid('test@example.com'));
+    }
+
+    public function testIsExistReturnsTrueWhenDisabled(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => false,
+            'getApiUrl' => '',
+            'getApiKey' => '',
+            'getMinimumHippoScore' => 0.0,
+            'isLoggingEnabled' => false,
+        ]);
+
+        $this->assertTrue($validator->isExist('test@example.com'));
+    }
+
+    public function testIsExistDetectsMissingMailbox(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => true,
+            'getApiUrl' => 'http://api',
+            'getApiKey' => 'key',
+            'getMinimumHippoScore' => 0.0,
+            'isLoggingEnabled' => false,
+        ], [
+            'emailVerification' => [
+                'mailboxVerification' => [
+                    'reason' => 'MailboxDoesNotExist',
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($validator->isExist('test@example.com'));
+    }
+
+    public function testIsExistReturnsTrueWhenMailboxExists(): void
+    {
+        $validator = $this->getValidator([
+            'isEnabled' => true,
+            'getApiUrl' => 'http://api',
+            'getApiKey' => 'key',
+            'getMinimumHippoScore' => 0.0,
+            'isLoggingEnabled' => false,
+        ], []);
+
+        $this->assertTrue($validator->isExist('test@example.com'));
+    }
+}
+


### PR DESCRIPTION
## Summary
- configure PHPUnit with composer
- add `Validator` unit tests
- run tests in GitHub Actions

## Testing
- `composer run-script test` *(fails: composer not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_685bb4b334a8832bb5931eb470964b50